### PR TITLE
Solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+*.tfvars
+*.tfvars.json
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.78.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:6MQ2q38HDc+UElLT8Sak5OqvxagxijWyElv259wTryQ=",
+    "h1:6rPRbUIYbOmHS9tuXwqMaC9SiI/94fsji+cfVyOmUmE=",
+    "h1:cVm/+wu+Xz5n2xqGKx8fEHop5a01+y5gmOM1xa0nCh8=",
+    "h1:izhAl+Nqiwj8gmTmye9Z2vHa2PIZtp/WoUuVuysDQdg=",
+    "zh:0d304aa909cc991ebde65d69c46f9843b08e88c3e9e0da14135ffa0da6aa2d16",
+    "zh:30e3e8ca8e21d58db6e6136bb04e62cfb2e1c6806598fb472e8d7a1a73911eec",
+    "zh:37b313bb082883568e16afe8f389bcf30e5eba0367b0dce52f5206d17237c8d8",
+    "zh:3fb84cfb9cce89e5abc5b066708a2aa84913bc5fa2c97d2aa89082a84de5fc51",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b622594b5024b3f7d37705e0fa2ceb7cd9fd6957e2d6f53b17b5dd7f6297cf4e",
+    "zh:c49ac67474cae86f6792db6042739a2a08a8ec38c5fcfd5d9764b5835595614a",
+    "zh:ce4031214a3f7ba267f1ae2d24b1e4e9e394af2afc4ea7833e67116a5042a614",
+    "zh:d0de2877cf64c91a7734cd170a4e1ec91e8822655760317b1a5e03c61cca3241",
+    "zh:e573830323bd1df38a0589e3f23c3f4124e1d8ab7875eeeec63e97fecdf48f4c",
+    "zh:f0c975ba9d6b7420f38e45e38adfe22f1b88ebed003bae35cb2c9223f36c79f5",
+    "zh:f75cc41e621ac23cbc948570672b191d69f9d4056342a8e82f1c59cb9f76b2df",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.8.4"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+
+  backend "local" {}
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "this" {
+  name     = var.resource_group_name
+  location = var.location
+}

--- a/main.tf
+++ b/main.tf
@@ -8,11 +8,18 @@ terraform {
     }
   }
 
-  backend "local" {}
+  backend "azurerm" {
+    resource_group_name  = "tfstate"
+    storage_account_name = "tfstatevlpstorage"
+    container_name       = "tfstate"
+    key                  = "terraform.tfstate"
+    use_oidc             = true
+  }
 }
 
 provider "azurerm" {
   features {}
+  use_oidc = true
 }
 
 resource "azurerm_resource_group" "this" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "resource_group_id" {
+  value = azurerm_resource_group.this.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,9 @@
+variable "resource_group_name" {
+  type    = string
+  default = "terraform-state-demo-rg"
+}
+
+variable "location" {
+  type    = string
+  default = "eastus"
+}


### PR DESCRIPTION
## Summary

Transition Terraform state from a **local** backend to a **remote `azurerm`** backend in Azure Blob Storage, using OIDC authentication for CI.

## Local → remote transition (addressing review)

The migration is now visible in `main.tf` and in the commit history:

| Commit | Backend in `main.tf` |
|--------|----------------------|
| `Set up local backend and Azure provider in main.tf` | `backend "local" {}` + `azurerm` provider |
| `Solution` | switched to `backend "azurerm"` (`resource_group_name` / `storage_account_name` / `container_name` / `key`) with `use_oidc = true`, provider also `use_oidc = true` |

The `terraform` and `provider` blocks were consolidated into `main.tf` as the task description suggests (`provider.tf` removed).

## OIDC wiring

`use_oidc = true` is set in **both** the backend and the provider blocks so GitHub Actions authenticates to Azure via a federated token — no secrets stored in the repo. The workflow expects these repo secrets: `AZURE_CLIENT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID` (already referenced in `.github/workflows/terraform-validate.yml`).

## Real verification against Azure

Backend resources were created and the configuration applied — the backend values in `main.tf` match real Azure resources:

```
$ az group create -n tfstate -l eastus
$ az storage account create -g tfstate -n tfstatevlpstorage --sku Standard_LRS
$ az storage container create -n tfstate --account-name tfstatevlpstorage

$ terraform init   # Successfully configured the backend "azurerm"!
$ terraform apply
azurerm_resource_group.this: Creation complete  [id=.../resourceGroups/terraform-state-demo-rg]
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

$ az storage blob list --container-name tfstate --account-name tfstatevlpstorage -o table
Name               Size    Modified
-----------------  ------  -------------------------
terraform.tfstate  1355    2026-06-26T17:15:45+00:00
```

The `terraform.tfstate` file is confirmed stored in the `tfstate` Blob container, and state locking worked during `plan`/`apply`.

## Successful workflow run

https://github.com/mate-academy/terraform_task_5_state/actions/runs/28253877451 ✅